### PR TITLE
patch v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ XRecord
 Version Changes Control
 =======================
 
+v0.4.0 - 2021-12-10
+-----------------------
+- Now all the xtable functions (Select, Update, Delete, Count, etc) can accept pointers parameters and nil casted parameters (for instance *XCondition or *XOrderBy than can be nil too).
+
 v0.3.3 - 2021-01-20
 -----------------------
 - Correction to support nil transactions (no transaction even if the parameter is passed with a nil value) into select type queries (select, min, max, avg, count, ...)

--- a/xbase.go
+++ b/xbase.go
@@ -18,7 +18,7 @@ As of 2018/12/01, only postgres and mysql are supported for now
 
 const (
 	// Version of XDominion
-	VERSION = "0.3.3"
+	VERSION = "0.4.0"
 
 	// The distinct supported databases
 	DB_Postgres  = "postgres"

--- a/xtable.go
+++ b/xtable.go
@@ -175,24 +175,61 @@ func (t *XTable) Select(args ...interface{}) (interface{}, error) {
 		case XCondition:
 			hasconditions = true
 			conditions = XConditions{p.(XCondition)}
+		case *XCondition:
+			if p != nil && p.(*XCondition) != nil {
+				fmt.Printf("DENTRO DEL TEST: %v, %p\n", p, p)
+
+				hasconditions = true
+				conditions = XConditions{*p.(*XCondition)}
+			}
 		case XConditions:
 			hasconditions = true
 			conditions = p.(XConditions)
+		case *XConditions:
+			if p != nil && p.(*XConditions) != nil {
+				hasconditions = true
+				conditions = *p.(*XConditions)
+			}
 		case XOrderBy:
 			hasorder = true
 			order = XOrder{p.(XOrderBy)}
+		case *XOrderBy:
+			if p != nil && p.(*XOrderBy) != nil {
+				hasorder = true
+				order = XOrder{*p.(*XOrderBy)}
+			}
 		case XOrder:
 			hasorder = true
 			order = p.(XOrder)
+		case *XOrder:
+			if p != nil && p.(*XOrder) != nil {
+				hasorder = true
+				order = *p.(*XOrder)
+			}
 		case XGroupBy:
 			hasgroup = true
 			group = XGroup{p.(XGroupBy)}
+		case *XGroupBy:
+			if p != nil && p.(*XGroupBy) != nil {
+				hasgroup = true
+				group = XGroup{*p.(*XGroupBy)}
+			}
 		case XGroup:
 			hasgroup = true
 			group = p.(XGroup)
+		case *XGroup:
+			if p != nil && p.(*XGroup) != nil {
+				hasgroup = true
+				group = *p.(*XGroup)
+			}
 		case XFieldSet:
 			hasfields = true
 			fields = p.(XFieldSet)
+		case *XFieldSet:
+			if p != nil && p.(*XFieldSet) != nil {
+				hasfields = true
+				fields = *p.(*XFieldSet)
+			}
 		case *XTransaction:
 			trx, hastrx = p.(*XTransaction)
 			if trx == nil {
@@ -542,9 +579,19 @@ func (t *XTable) Update(args ...interface{}) (int, error) {
 		case XCondition:
 			hasconditions = true
 			conditions = XConditions{p.(XCondition)}
+		case *XCondition:
+			if p != nil && p.(*XCondition) != nil {
+				hasconditions = true
+				conditions = XConditions{*p.(*XCondition)}
+			}
 		case XConditions:
 			hasconditions = true
 			conditions = p.(XConditions)
+		case *XConditions:
+			if p != nil && p.(*XConditions) != nil {
+				hasconditions = true
+				conditions = *p.(*XConditions)
+			}
 		case XRecord:
 			hasrecord = true
 			np := p.(XRecord)
@@ -655,9 +702,19 @@ func (t *XTable) Upsert(args ...interface{}) (int, error) {
 		case XCondition:
 			hasconditions = true
 			conditions = XConditions{p.(XCondition)}
+		case *XCondition:
+			if p != nil && p.(*XCondition) != nil {
+				hasconditions = true
+				conditions = XConditions{*p.(*XCondition)}
+			}
 		case XConditions:
 			hasconditions = true
 			conditions = p.(XConditions)
+		case *XConditions:
+			if p != nil && p.(*XConditions) != nil {
+				hasconditions = true
+				conditions = *p.(*XConditions)
+			}
 		case XRecord:
 			hasrecord = true
 			np := p.(XRecord)
@@ -726,9 +783,19 @@ func (t *XTable) Delete(args ...interface{}) (int, error) {
 		case XCondition:
 			hasconditions = true
 			conditions = XConditions{p.(XCondition)}
+		case *XCondition:
+			if p != nil && p.(*XCondition) != nil {
+				hasconditions = true
+				conditions = XConditions{*p.(*XCondition)}
+			}
 		case XConditions:
 			hasconditions = true
 			conditions = p.(XConditions)
+		case *XConditions:
+			if p != nil && p.(*XConditions) != nil {
+				hasconditions = true
+				conditions = *p.(*XConditions)
+			}
 		}
 	}
 
@@ -790,9 +857,19 @@ func (t *XTable) Count(args ...interface{}) (int, error) {
 		case XCondition:
 			hasconditions = true
 			conditions = XConditions{p.(XCondition)}
+		case *XCondition:
+			if p != nil && p.(*XCondition) != nil {
+				hasconditions = true
+				conditions = XConditions{*p.(*XCondition)}
+			}
 		case XConditions:
 			hasconditions = true
 			conditions = p.(XConditions)
+		case *XConditions:
+			if p != nil && p.(*XConditions) != nil {
+				hasconditions = true
+				conditions = *p.(*XConditions)
+			}
 		case *XTransaction:
 			trx, hastrx = p.(*XTransaction)
 			if trx == nil {
@@ -857,9 +934,19 @@ func (t *XTable) Min(field string, args ...interface{}) (interface{}, error) {
 		case XCondition:
 			hasconditions = true
 			conditions = XConditions{p.(XCondition)}
+		case *XCondition:
+			if p != nil && p.(*XCondition) != nil {
+				hasconditions = true
+				conditions = XConditions{*p.(*XCondition)}
+			}
 		case XConditions:
 			hasconditions = true
 			conditions = p.(XConditions)
+		case *XConditions:
+			if p != nil && p.(*XConditions) != nil {
+				hasconditions = true
+				conditions = *p.(*XConditions)
+			}
 		case *XTransaction:
 			trx, hastrx = p.(*XTransaction)
 			if trx == nil {
@@ -920,9 +1007,19 @@ func (t *XTable) Max(field string, args ...interface{}) (interface{}, error) {
 		case XCondition:
 			hasconditions = true
 			conditions = XConditions{p.(XCondition)}
+		case *XCondition:
+			if p != nil && p.(*XCondition) != nil {
+				hasconditions = true
+				conditions = XConditions{*p.(*XCondition)}
+			}
 		case XConditions:
 			hasconditions = true
 			conditions = p.(XConditions)
+		case *XConditions:
+			if p != nil && p.(*XConditions) != nil {
+				hasconditions = true
+				conditions = *p.(*XConditions)
+			}
 		case *XTransaction:
 			trx, hastrx = p.(*XTransaction)
 			if trx == nil {
@@ -983,9 +1080,19 @@ func (t *XTable) Avg(field string, args ...interface{}) (interface{}, error) {
 		case XCondition:
 			hasconditions = true
 			conditions = XConditions{p.(XCondition)}
+		case *XCondition:
+			if p != nil && p.(*XCondition) != nil {
+				hasconditions = true
+				conditions = XConditions{*p.(*XCondition)}
+			}
 		case XConditions:
 			hasconditions = true
 			conditions = p.(XConditions)
+		case *XConditions:
+			if p != nil && p.(*XConditions) != nil {
+				hasconditions = true
+				conditions = *p.(*XConditions)
+			}
 		case *XTransaction:
 			trx, hastrx = p.(*XTransaction)
 			if trx == nil {

--- a/xtable_test.go
+++ b/xtable_test.go
@@ -1,0 +1,54 @@
+package xdominion
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestXTable_select(t *testing.T) {
+
+	base := &XBase{
+		DBType:   DB_Postgres,
+		Username: "username",
+		Password: "password",
+		Database: "test",
+		Host:     DB_Localhost,
+		SSL:      false,
+	}
+	base.Logon()
+
+	tb := getTableDef(base)
+	tb.Synchronize()
+	buildData(tb)
+
+	var where *XCondition
+	var order *XOrderBy
+
+	r, err := tb.SelectAll(where, order)
+	fmt.Println(r, err)
+
+}
+
+func buildData(tb *XTable) {
+	// insert some things
+	_, err := tb.Insert(XRecord{"f1": 3, "f2": "Data line 1"})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	_, err = tb.Insert(XRecord{"f1": 4, "f2": "Data line 2"})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	_, err = tb.Insert(XRecord{"f1": 5, "f2": "Data line 1"})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	_, err = tb.Insert(XRecord{"f1": 6, "f2": "Data line 2"})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+}


### PR DESCRIPTION
- Now all the xtable functions (Select, Update, Delete, Count, etc) can accept pointers parameters and nil casted parameters (for instance *XCondition or *XOrderBy than can be nil too).
