### PR TITLE
patch v0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ XRecord
 Version Changes Control
 =======================
 
+v0.4.2 - 2022-06-13
+-----------------------
+- Correction of a bug on DoSelect with limits, a 0 limit is not a limit
+
+v0.4.1 - 2022-01-19
+-----------------------
+- XConditions, XCondition, XOrder, XOrderBy, XFieldSet can now be cloned with <object>.Clone()
+
 v0.4.0 - 2021-12-10
 -----------------------
 - Now all the xtable functions (Select, Update, Delete, Count, etc) can accept pointers parameters and nil casted parameters (for instance *XCondition or *XOrderBy than can be nil too).

--- a/xbase.go
+++ b/xbase.go
@@ -18,7 +18,7 @@ As of 2018/12/01, only postgres and mysql are supported for now
 
 const (
 	// Version of XDominion
-	VERSION = "0.4.0"
+	VERSION = "0.4.2"
 
 	// The distinct supported databases
 	DB_Postgres  = "postgres"

--- a/xcondition.go
+++ b/xcondition.go
@@ -46,6 +46,15 @@ func (c *XConditions) CreateConditions(table *XTable, DB string, baseindex int) 
 	return cond, data
 }
 
+func (c *XConditions) Clone() XConditions {
+	nc := XConditions{}
+	for _, xc := range *c {
+		nxc := xc.Clone()
+		nc = append(nc, nxc)
+	}
+	return nc
+}
+
 /*
   The XCondition structure
 */
@@ -155,4 +164,17 @@ func (c *XCondition) GetCondition(table *XTable, DB string, baseindex int) (stri
 	}
 
 	return cond, value, indexused
+}
+
+func (c *XCondition) Clone() XCondition {
+	nc := XCondition{
+		Field:          c.Field,
+		Operator:       c.Operator,
+		Limit:          c.Limit,
+		LimitExtra:     c.LimitExtra,
+		OperatorGlobal: c.OperatorGlobal,
+		AtomOpen:       c.AtomOpen,
+		AtomClose:      c.AtomClose,
+	}
+	return nc
 }

--- a/xorderby.go
+++ b/xorderby.go
@@ -26,6 +26,15 @@ func (o *XOrder) CreateOrder(table *XTable, DB string) string {
 	return order
 }
 
+func (o *XOrder) Clone() XOrder {
+	no := XOrder{}
+	for _, xo := range *o {
+		nxo := xo.Clone()
+		no = append(no, nxo)
+	}
+	return no
+}
+
 /*
   The XOrderBy structure
 */
@@ -54,4 +63,12 @@ func (c *XOrderBy) GetOrder(table *XTable, DB string) string {
 		order += " " + c.Operator
 	}
 	return order
+}
+
+func (o *XOrderBy) Clone() XOrderBy {
+	no := XOrderBy{
+		Field:    o.Field,
+		Operator: o.Operator,
+	}
+	return no
 }

--- a/xtable.go
+++ b/xtable.go
@@ -309,7 +309,7 @@ func (t *XTable) Select(args ...interface{}) (interface{}, error) {
 	// having, needs a group by, set of conditions
 
 	// 5. Limits
-	if haslimit {
+	if haslimit && limit > 0 {
 		sql += " limit " + strconv.Itoa(limit)
 	}
 	if hasoffset {


### PR DESCRIPTION
- Correction of a bug on DoSelect with limits, a 0 limit is not a limit
- XConditions, XCondition, XOrder, XOrderBy, XFieldSet can now be cloned with <object>.Clone()
